### PR TITLE
add x-roles header to outgoing service request

### DIFF
--- a/jwt-wallet.go
+++ b/jwt-wallet.go
@@ -3,6 +3,7 @@ package jwtwallet
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/provenance-io/kong-jwt-wallet/grants"
 	"github.com/provenance-io/kong-jwt-wallet/signing"
 
@@ -62,7 +63,7 @@ func (conf Config) Access(kong *pdk.PDK) {
 		kong.Response.Exit(500, "someting went wrong", x)
 		return
 	}
-	kong.Response.AddHeader("x-roles", string(grantsJson))
+	kong.ServiceRequest.AddHeader("x-roles", string(grantsJson))
 	//
 	kong.Log.Warn(tok)
 

--- a/jwt-wallet.go
+++ b/jwt-wallet.go
@@ -64,7 +64,7 @@ func (conf Config) Access(kong *pdk.PDK) {
 		return
 	}
 	kong.ServiceRequest.AddHeader("x-roles", string(grantsJson))
-	//
+
 	kong.Log.Warn(tok)
 
 }


### PR DESCRIPTION
* `x-roles` header was incorrectly added to the kong response header.