### PR TITLE
updates to test locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 ## go install github.com/provenance-io/kong-jwt-wallet/cmd/jwt-wallet@latest
 RUN go build -o jwt-wallet ./cmd/jwt-wallet
 
-FROM kong:2.4.1-alpine
+FROM kong:2.7.0-alpine
 # Once the repo made public, this can become:
 ## COPY --from=build /go/bin/jwt-wallet /usr/local/bin/
 COPY --from=build /app/jwt-wallet /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ docker:
 
 .PHONY: docker-run
 docker-run:
-	docker run --net host -it --name kong-test --rm \
+	docker run -it --name kong-test --rm \
 		-v $(CURDIR)/config.yml:/opt/config.yml \
 		-e "KONG_DATABASE=off" \
 		-e "KONG_LOG_LEVEL=debug" \
@@ -62,7 +62,7 @@ docker-run:
 
 .PHONY: docker-bash
 docker-bash:
-	docker run --net host -it --name kong-test --rm \
+	docker run -it --name kong-test --rm \
 		-e "KONG_DATABASE=off" \
 		-e "KONG_LOG_LEVEL=debug" \
 		-e "KONG_PROXY_LISTEN=0.0.0.0:8000" \

--- a/README.md
+++ b/README.md
@@ -18,9 +18,19 @@ When using the plugin, add it to your kong service definition and include an rba
 
 ### Running locally
 
+Run via docker:
 ```
 make docker && make docker-run
 ```
+
+Use `config.yml` to update the settings for your local running environment.
+Point the `rbac` url to a running copy of RBAC Service or serve the included example payload from the `http/` directory by running: 
+```
+make http
+```
+
+When using the example payload, use the value from `/token` as the JWT/Bearer token for your request.
+
 
 ## Creating a JWT
 

--- a/config.yml
+++ b/config.yml
@@ -8,5 +8,6 @@ services:
   plugins:
   - name: jwt-wallet
     config:
-#      rbac: http://localhost:8888/api/v1/rbac/account/{addr}/grants
-      rbac: http://localhost:8888/{addr}/index.html
+#      rbac: http://localhost:8888/api/v1/rbac/account/{addr}/grants    # Running RBAC Service
+#      rbac: http://docker.for.mac.host.internal:8888/{addr}/index.html # Use when running `make http` on Mac
+      rbac: http://localhost:8888/{addr}/index.html                     # Use when running `make http` on Linux


### PR DESCRIPTION
These changes were necessary for local testing. Most notably: 
```
/usr/local/share/lua/5.1/kong/init.lua:502: in function 'init'
        init_by_lua:3: in main chunk
nginx: [error] init_by_lua error: ...local/share/lua/5.1/kong/runloop/plugin_servers/init.lua:110: module 'kong.runloop.plugin_servers.pb_rpc' not found:No LuaRocks module found for kong.runloop.plugin_servers.pb_rpc
        no field package.preload['kong.runloop.plugin_servers.pb_rpc']
        no file './kong/runloop/plugin_servers/pb_rpc.lua'
```