### PR TITLE
Return whole subject instead of only grants

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Configuration options:
 * `rbac`* - Full path to your running RBAC service. The rbac url should contain an `{addr}` string representing the wallet address. If not set then the plugin will only verify a user signed JWT and will not retrieve delegated access rights or include the x-wallet-access header. 
 * `apikey` - API Key to use when making a call to the RBAC service
 * `authHeader` - The name of the request header containing the JWT. Defaults to "Authorization". 
-- Requires the Bearer token format e.g {authHeader} Bearer {jwt}
+  - Requires the Bearer token format e.g {authHeader} Bearer {jwt}
 * `accessHeader` - The name of the header to inject with the wallet access JSON. Defaults to "x-wallet-access". Only injected when rbac configuration is set
 * `senderHeader` - The name of the header to inject with the addr claim of the user signed JWT. If not set then will not inject
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Recommended configuration:
 Configuration options:
 * `rbac`* - Full path to your running RBAC service. The rbac url should contain an `{addr}` string representing the wallet address. If not set then the plugin will only verify a user signed JWT and will not retrieve delegated access rights or include the x-wallet-access header. 
 * `apikey` - API Key to use when making a call to the RBAC service
-* `authHeader` - The name of the request header containing the JWT. Defaults to "Authorization". Requires the Bearer token format 
-e.g {authHeader} Bearer {jwt}
+* `authHeader` - The name of the request header containing the JWT. Defaults to "Authorization". 
+- Requires the Bearer token format e.g {authHeader} Bearer {jwt}
 * `accessHeader` - The name of the header to inject with the wallet access JSON. Defaults to "x-wallet-access". Only injected when rbac configuration is set
 * `senderHeader` - The name of the header to inject with the addr claim of the user signed JWT. If not set then will not inject
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Recommended configuration:
 Configuration options:
 * `rbac`* - Full path to your running RBAC service. The rbac url should contain an `{addr}` string representing the wallet address. If not set then the plugin will only verify a user signed JWT and will not retrieve delegated access rights or include the x-wallet-access header. 
 * `apikey` - API Key to use when making a call to the RBAC service
-* `authHeader` - The name of the request header containing the JWT. Defaults to "Authorization"
+* `authHeader` - The name of the request header containing the JWT. Defaults to "Authorization". Requires the Bearer token format 
+e.g {authHeader} Bearer {jwt}
 * `accessHeader` - The name of the header to inject with the wallet access JSON. Defaults to "x-wallet-access". Only injected when rbac configuration is set
 * `senderHeader` - The name of the header to inject with the addr claim of the user signed JWT. If not set then will not inject
 

--- a/cmd/jwt-wallet/main_test.go
+++ b/cmd/jwt-wallet/main_test.go
@@ -153,7 +153,7 @@ func TestValidJwt(t *testing.T) {
 	assert.Equal(t, 200, env.ClientRes.Status)
 	assert.NotEmpty(t, env.ServiceReq.Headers.Get("x-wallet-access"))
 	assert.Empty(t, env.ServiceReq.Headers.Get("x-sender"))
-	assert.Equal(t, xRoles, env.ServiceReq.Headers.Get("x-wallet-access"))
+	assert.Equal(t, subjectJSONString, env.ServiceReq.Headers.Get("x-wallet-access"))
 }
 
 func TestValidJwtWithEmptyRbacUrl(t *testing.T) {
@@ -220,25 +220,4 @@ func GenerateClaims(addr string, pubKey *secp256k1.PublicKey) *signing.Claims {
 	}
 }
 
-var subjectJSONString = `
-{
-	"address": "1337-wallet",
-	"name": "jwt-wallet",
-	"grants": [
-		{
-			"address": "1337-wallet",
-			"name": "jwt-wallet",
-			"authzGrants": [],
-			"applications": [
-				{
-					"name": "myapp",
-					"permissions": [
-						"1337_role"
-					]
-				}
-			]
-		}
-	]
-}`
-
-var xRoles = `[{"address":"1337-wallet","name":"jwt-wallet","authzGrants":[],"applications":[{"name":"myapp","permissions":["1337_role"]}]}]`
+var subjectJSONString = `{"address":"1337-wallet","name":"jwt-wallet","grants":[{"address":"1337-wallet","name":"jwt-wallet","authzGrants":[],"applications":[{"name":"myapp","permissions":["1337_role"]}]}]}`

--- a/grants/grants.go
+++ b/grants/grants.go
@@ -36,7 +36,7 @@ func init() {
 	Client = &http.Client{}
 }
 
-func GetGrants(grantsURL string, address string, apiKey string) (*[]GrantedAccess, error) {
+func GetGrants(grantsURL string, address string, apiKey string) (*SubjectResponse, error) {
 	uri := strings.ReplaceAll(grantsURL, "{addr}", address)
 	request, _ := http.NewRequest("GET", uri, nil)
 	request.Header.Add("x-sender", address)
@@ -61,5 +61,5 @@ func GetGrants(grantsURL string, address string, apiKey string) (*[]GrantedAcces
 		return nil, err
 	}
 
-	return &response.Grants, nil
+	return &response, nil
 }

--- a/jwt-wallet.go
+++ b/jwt-wallet.go
@@ -88,7 +88,7 @@ func (conf Config) Access(kong *pdk.PDK) {
 	}
 
 	if conf.RBAC != "" {
-		kong.ServiceRequest.AddHeader(conf.AccessHeader, string(accessJson))
+		kong.ServiceRequest.SetHeader(conf.AccessHeader, string(accessJson))
 	}
 
 	if conf.SenderHeader != "" {

--- a/jwt-wallet.go
+++ b/jwt-wallet.go
@@ -101,7 +101,7 @@ func (conf Config) Access(kong *pdk.PDK) {
 
 var parser = jwt.NewParser()
 
-func handleGrantedAccess(token *jwt.Token, url string, apiKey string, kong *pdk.PDK) (*[]grants.GrantedAccess, string, error) {
+func handleGrantedAccess(token *jwt.Token, url string, apiKey string, kong *pdk.PDK) (*grants.SubjectResponse, string, error) {
 	if claims, ok := token.Claims.(*signing.Claims); ok {
 		if claims.Addr == "" {
 			return nil, "", fmt.Errorf("missing addr claim")
@@ -112,11 +112,11 @@ func handleGrantedAccess(token *jwt.Token, url string, apiKey string, kong *pdk.
 		}
 
 		if url != "" {
-			grantedAccess, err := grants.GetGrants(url, claims.Addr, apiKey)
+			subjectResponse, err := grants.GetGrants(url, claims.Addr, apiKey)
 			if err != nil {
 				return nil, "", err
 			}
-			return grantedAccess, claims.Addr, nil
+			return subjectResponse, claims.Addr, nil
 		}
 		return nil, claims.Addr, nil
 	}


### PR DESCRIPTION
Also use SetHeader as AddHeader won't overwrite existing headers (someone could send their own access header and won't get overwritten)


<img width="860" alt="image" src="https://user-images.githubusercontent.com/89096689/170378344-814530e3-312c-4a0a-b6ee-8e0a814507b8.png">
