### PR TITLE
remove authz grants from header

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Wallet access header content:
 		{
 			"address": "grantor_address",
 			"name": "grantor name",
-			"authzGrants": ["list", "of", "authz", "grants"],
 			"applications": [
 				{
 					"name": "application_name",
@@ -29,7 +28,7 @@ Wallet access header content:
 
 ## Getting started
 
-When using this plugin you can use `go install github.com/provenance-io/kong-jwt-wallet/cmd/jwt-wallet@v0.7.0` directly or download a release version (soon to come)
+When using this plugin you can use `go install github.com/provenance-io/kong-jwt-wallet/cmd/jwt-wallet@v0.10.0` directly or download a release version (soon to come)
 
 ### Configuration
 

--- a/cmd/jwt-wallet/main_test.go
+++ b/cmd/jwt-wallet/main_test.go
@@ -220,4 +220,4 @@ func GenerateClaims(addr string, pubKey *secp256k1.PublicKey) *signing.Claims {
 	}
 }
 
-var subjectJSONString = `{"address":"1337-wallet","name":"jwt-wallet","grants":[{"address":"1337-wallet","name":"jwt-wallet","authzGrants":[],"applications":[{"name":"myapp","permissions":["1337_role"]}]}]}`
+var subjectJSONString = `{"address":"1337-wallet","name":"jwt-wallet","grants":[{"address":"1337-wallet","name":"jwt-wallet","applications":[{"name":"myapp","permissions":["1337_role"]}]}]}`

--- a/grants/grants.go
+++ b/grants/grants.go
@@ -15,9 +15,8 @@ type SubjectResponse struct {
 }
 
 type GrantedAccess struct {
-	Address      string   `json:"address"`
-	Name         string   `json:"name"`
-	AuthzGrants  []string `json:"authzGrants"`
+	Address      string `json:"address"`
+	Name         string `json:"name"`
 	Applications []struct {
 		Name        string   `json:"name"`
 		Permissions []string `json:"permissions"`

--- a/http/tp1uz5g72pvfrdnm9qnjpyvsnwc64d4wygyqanx2t/index.html
+++ b/http/tp1uz5g72pvfrdnm9qnjpyvsnwc64d4wygyqanx2t/index.html
@@ -5,7 +5,6 @@
 		{
 			"address": "tp1uz5g72pvfrdnm9qnjpyvsnwc64d4wygyqanx2t",
 			"name": "jwt-wallet",
-			"authzGrants": [],
 			"applications": [
 				{
 					"name": "my_app",


### PR DESCRIPTION
The RBAC authz grant model is changing from a string to an object to more accurately identify the authorization. Given that the grants are not currently used from the header, this adds significant unnecessary size. 

Removing the grants from the header so that only permissions will now be included.